### PR TITLE
MRR calculation adjustments

### DIFF
--- a/models/stripe__invoice_discount.sql
+++ b/models/stripe__invoice_discount.sql
@@ -11,5 +11,5 @@ select
   max(subtotal) as subtotal, 
   max(total)::decimal / max(subtotal) as discount_factor
 from invoice_line_item
-where amount_due > 0
+where subtotal <> 0
 group by invoice_line_item.invoice_id

--- a/models/stripe__invoice_line_items.sql
+++ b/models/stripe__invoice_line_items.sql
@@ -73,7 +73,7 @@ select
     ,invoice_line_item.proration,
     case plan.plan_interval
         when 'week' then plan.interval_count * 4
-        when 'month' then plan.interval_count
+        when 'month' then (1::FLOAT/plan.interval_count::FLOAT)
         when 'year' then plan.interval_count / 12.0
     end as subscription_duration_ratio,
     case


### PR DESCRIPTION
After some comparison with Stripe's MRR calculation there are some adjustments that need to be made:
- Amount due: sometimes credits are applied to the invoice, so we have to consider also zero amount due.
- The subscription duration ratio was incorrect for quarterly plans.
- If the prorate takes place in a month different from the product's period start, it's prorated value is not considered in the calculation.
